### PR TITLE
Implement extra metadata tracking for jobs

### DIFF
--- a/src/iceqube/client.py
+++ b/src/iceqube/client.py
@@ -16,13 +16,20 @@ class Client(object):
         """
         Schedules a function func for execution.
 
-        The only other special parameter is track_progress. If passed in and not None, the func will be passed in a
+        One special parameter is track_progress. If passed in and not None, the func will be passed in a
         keyword parameter called update_progress:
 
         def update_progress(progress, total_progress, stage=""):
 
         The running function can call the update_progress function to notify interested parties of the function's
         current progress.
+
+        Another special parameter is the "cancellable" keyword parameter. When passed in and not None, a special
+        "check_for_cancel" parameter is passed in. When called, it raises an error when the user has requested a job
+        to be cancelled.
+
+        The caller can also pass in any pickleable object into the "extra_metadata" parameter. This data is stored
+        within the job and can be retrieved when the job status is queried.
 
         All other parameters are directly passed to the function when it starts running.
 
@@ -40,6 +47,7 @@ class Client(object):
 
         job.track_progress = kwargs.pop('track_progress', False)
         job.cancellable = kwargs.pop('cancellable', False)
+        job.extra_metadata = kwargs.pop('extra_metadata', {})
         job_id = self.storage.schedule_job(job)
         return job_id
 

--- a/tests/common/test_classes.py
+++ b/tests/common/test_classes.py
@@ -158,6 +158,13 @@ class TestClient(object):
         # is the job recorded in the chosen backend?
         assert inmem_client.status(job_id).job_id == job_id
 
+    def test_schedule_preserves_extra_metadata(self, inmem_client):
+        metadata = {"saved": True}
+        job_id = inmem_client.schedule(id, 1, extra_metadata=metadata)
+
+        # Do we get back the metadata we save?
+        assert inmem_client.status(job_id).extra_metadata == metadata
+
     def test_schedule_runs_function(self, inmem_client, flag):
         job_id = inmem_client.schedule(set_flag, flag)
 


### PR DESCRIPTION
- To be used by Kolibri to track which user triggered a job.
- Consequently, we upgrade Iceqube to 0.0.4.