### PR TITLE
Make API parallel to RQ add RQ Scheduler style task scheduler

### DIFF
--- a/src/iceqube/classes.py
+++ b/src/iceqube/classes.py
@@ -61,6 +61,13 @@ class Job(object):
         :param func: func can be a callable object, in which case it is turned into an importable string,
         or it can be an importable string already.
         """
+        if isinstance(func, Job):
+            args = copy.copy(func.args)
+            kwargs = copy.copy(func.kwargs)
+            kwargs['track_progress'] = func.track_progress
+            kwargs['cancellable'] = func.cancellable
+            kwargs['extra_metadata'] = func.extra_metadata.copy()
+            func = func.func
         self.job_id = uuid.uuid4().hex
         self.state = kwargs.pop('state', State.QUEUED)
         self.traceback = ""

--- a/src/iceqube/classes.py
+++ b/src/iceqube/classes.py
@@ -1,5 +1,7 @@
 import copy
 import logging
+import uuid
+
 from functools import partial
 
 from iceqube.utils import import_stringified_func, stringify_func
@@ -59,7 +61,7 @@ class Job(object):
         :param func: func can be a callable object, in which case it is turned into an importable string,
         or it can be an importable string already.
         """
-        self.job_id = kwargs.pop('job_id', None)
+        self.job_id = uuid.uuid4().hex
         self.state = kwargs.pop('state', State.QUEUED)
         self.traceback = ""
         self.exception = None

--- a/src/iceqube/scheduler.py
+++ b/src/iceqube/scheduler.py
@@ -1,0 +1,234 @@
+import time
+
+from datetime import datetime
+from datetime import timedelta
+from contextlib import contextmanager
+
+from sqlalchemy import Column, DateTime, Index, Integer, PickleType, String, create_engine, event
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
+
+from iceqube.classes import Job
+from iceqube.classes import State
+from iceqube.exceptions import JobNotFound
+from iceqube.queue import Queue
+from iceqube.utils import InfiniteLoopThread
+
+Base = declarative_base()
+
+
+DEFAULT_INTERVAL = 60
+
+
+class ScheduledJob(Base):
+    """
+    The DB representation of a scheduled job,
+    storing the relevant details needed to schedule jobs.
+    """
+    __tablename__ = "scheduledjobs"
+
+    # The hex UUID given to the job upon first creation
+    id = Column(String, primary_key=True, autoincrement=False)
+
+    # Repeat interval in seconds.
+    interval = Column(Integer, default=0)
+
+    # Number of times to repeat - None means repeat forever.
+    repeat = Column(Integer, nullable=True)
+
+    # The app name passed to the client when the job is scheduled.
+    queue = Column(String, index=True)
+
+    # The original Job object, pickled here for so we can easily access it.
+    obj = Column(PickleType)
+
+    scheduled_time = Column(DateTime())
+
+    __table_args__ = (Index('queue__scheduled_time', 'queue', 'scheduled_time'),)
+
+
+class Scheduler(object):
+
+    def __init__(self, queue, storage_path=None, interval=DEFAULT_INTERVAL):
+        if storage_path is None:
+            raise ValueError('Storage path must be defined')
+        if not isinstance(queue, Queue):
+            raise ValueError('The passed in queue must be an instance of a Queue')
+        self.queue = queue
+
+        self.interval = interval
+
+        storage_path = "sqlite:///{path}".format(path=storage_path)
+
+        self.engine = create_engine(
+            storage_path,
+            connect_args={'check_same_thread': False},
+            poolclass=NullPool)
+        self.set_sqlite_pragmas()
+        Base.metadata.create_all(self.engine)
+        self.sessionmaker = sessionmaker(bind=self.engine)
+
+    @contextmanager
+    def session_scope(self):
+        session = self.sessionmaker()
+        try:
+            yield session
+            session.commit()
+        except:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def set_sqlite_pragmas(self):
+        """
+        Sets the connection PRAGMAs for the sqlalchemy engine stored in self.engine.
+
+        It currently sets:
+        - journal_mode to WAL
+
+        :return: None
+        """
+
+        def _pragmas_on_connect(dbapi_con, con_record):
+            dbapi_con.execute("PRAGMA journal_mode = WAL;")
+
+        event.listen(self.engine, "connect", _pragmas_on_connect)
+
+    def start_schedule_checker(self):
+        """
+        Starts up the job checker thread, that starts scheduled jobs when there are workers free,
+        and checks for cancellation requests for jobs currently assigned to a worker.
+        Returns: the Thread object.
+        """
+        t = InfiniteLoopThread(self.check_schedule, thread_name="SCHEDULECHECKER", wait_between_runs=self.interval)
+        t.start()
+        return t
+
+    def run(self):
+        """
+        Start the schedule checker in a blocking way to be parallel to the rq-scheduler method.
+        """
+        thread = self.start_schedule_checker()
+        thread.join()
+
+    def start_scheduler(self):
+        if not self._schedule_checker or not self._schedule_checker.is_alive():
+            self._schedule_checker = self.start_schedule_checker()
+
+    def shutdown_scheduler(self):
+        if self._scheduler_checker:
+            self._scheduler_checker.stop()
+
+    def enqueue_at(self, dt, func, *args, **kwargs):
+        """
+        Add the job to the scheduler for the specified time
+        """
+        return self.schedule(dt, func, interval=0, repeat=0, *args, **kwargs)
+
+    def enqueue_in(self, delta_t, func, *args, **kwargs):
+        """
+        Add the job to the scheduler in the specified time delta
+        """
+        if not isinstance(delta_t, timedelta):
+            raise ValueError('Time argument must be a timedelta object.')
+        dt = self._now() + delta_t
+        return self.schedule(dt, func, interval=0, repeat=0, *args, **kwargs)
+
+    def schedule(self, dt, func, interval=0, repeat=0, *args, **kwargs):
+        """
+        Add the job to the scheduler for the specified time, interval, and number of repeats.
+        Repeat of None with a specified interval means the job will repeat forever at that
+        interval.
+        """
+        if not isinstance(dt, datetime):
+            raise ValueError('Time argument must be a datetime object.')
+        if not interval and repeat != 0:
+            raise ValueError('Must specify an interval if the task is repeating')
+        if isinstance(func, Job):
+            job = func
+        # else, turn it into a job first.
+        else:
+            job = Job(func, *args, **kwargs)
+
+        job.state = State.SCHEDULED
+
+        with self.session_scope() as session:
+            scheduled_job = ScheduledJob(
+                id=job.job_id,
+                queue=self.queue.name,
+                interval=interval,
+                repeat=repeat,
+                scheduled_time=dt,
+                obj=job)
+            session.add(scheduled_job)
+
+            return job.job_id
+
+    def get_jobs(self):
+        with self.session_scope() as s:
+            scheduled_jobs = self._ns_query(s).all()
+            return [o.obj for o in scheduled_jobs]
+
+    def count(self):
+        with self.session_scope() as s:
+            return self._ns_query(s).count()
+
+    def get_job(self, job_id):
+        with self.session_scope() as session:
+            scheduled_job = self._ns_query(session).filter_by(id=job_id).one_or_none()
+            if scheduled_job is None:
+                raise JobNotFound()
+            return scheduled_job.obj
+
+    def cancel(self, job_id):
+        """
+        Clear a scheduled job.
+        :type job_id: NoneType or str
+        :param job_id: the job_id to clear. If None, clear all jobs.
+        """
+        with self.session_scope() as s:
+            q = self._ns_query(s)
+            if job_id:
+                q = q.filter_by(id=job_id)
+
+            q.delete(synchronize_session=False)
+
+    def check_schedule(self):
+        start = time.time()
+        now = self._now()
+        with self.session_scope() as s:
+            scheduled_jobs = self._ns_query(s).filter(ScheduledJob.scheduled_time <= now)
+            for scheduled_job in scheduled_jobs:
+                new_repeat = 0
+                repeat = False
+                if scheduled_job.repeat is None:
+                    new_repeat = None
+                    repeat = True
+                elif scheduled_job.repeat > 0:
+                    new_repeat = scheduled_job.repeat - 1
+                    repeat = True
+                job_for_queue = scheduled_job.obj
+                if repeat:
+                    # Schedule another job to repeat this
+                    new_job = Job(job_for_queue)
+                    self.schedule(
+                        self._now() + timedelta(seconds=scheduled_job.interval),
+                        new_job,
+                        interval=scheduled_job.interval,
+                        repeat=new_repeat,
+                    )
+                self.queue.enqueue(job_for_queue)
+                s.delete(scheduled_job)
+            return time.time() - start
+
+    def _ns_query(self, session):
+        """
+        Return a SQLAlchemy query that is already namespaced by the queue.
+        Returns: a SQLAlchemy query object
+        """
+        return session.query(ScheduledJob).filter(ScheduledJob.queue == self.queue.name)
+
+    def _now(self):
+        return datetime.utcnow()

--- a/src/iceqube/storage.py
+++ b/src/iceqube/storage.py
@@ -41,8 +41,8 @@ class ORMJob(Base):
     time_updated = Column(DateTime(timezone=True), server_onupdate=func.now())
 
 
-class Storage(object):
-    def __init__(self, connection, *args, **kwargs):
+class StorageMixin(object):
+    def __init__(self, connection, Base=Base):
         self.engine = connection
         if self.engine.name == "sqlite":
             self.set_sqlite_pragmas()
@@ -75,6 +75,8 @@ class Storage(object):
         except OperationalError:
             pass
 
+
+class Storage(StorageMixin):
     def enqueue_job(self, j, queue):
         """
         Add the job given by j to the job queue.

--- a/src/iceqube/storage.py
+++ b/src/iceqube/storage.py
@@ -1,9 +1,8 @@
 import logging
-import uuid
 from contextlib import contextmanager
 from copy import copy
 
-from sqlalchemy import Column, DateTime, Index, Integer, PickleType, String, event, func, or_
+from sqlalchemy import Column, DateTime, Integer, PickleType, String, func, or_
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
@@ -20,6 +19,7 @@ class ORMJob(Base):
     storing the relevant details needed by the job storage
     backend.
     """
+
     __tablename__ = "jobs"
 
     # The hex UUID given to the job upon first creation
@@ -31,11 +31,8 @@ class ORMJob(Base):
     # The job's order in the entire global queue of jobs.
     queue_order = Column(Integer, autoincrement=True)
 
-    # The app name passed to the client when the job is scheduled.
-    app = Column(String, index=True)
-
-    # The app name passed to the client when the job is scheduled.
-    namespace = Column(String, index=True)
+    # The queue name passed to the client when the job is scheduled.
+    queue = Column(String, index=True)
 
     # The original Job object, pickled here for so we can easily access it.
     obj = Column(PickleType)
@@ -43,15 +40,9 @@ class ORMJob(Base):
     time_created = Column(DateTime(timezone=True), server_default=func.now())
     time_updated = Column(DateTime(timezone=True), server_onupdate=func.now())
 
-    __table_args__ = (Index('app_namespace_index', 'app', 'namespace'),)
-
 
 class Storage(object):
-
-    def __init__(self, app, namespace, connection, *args, **kwargs):
-        self.app = app
-        self.namespace = namespace
-
+    def __init__(self, connection, *args, **kwargs):
         self.engine = connection
         if self.engine.name == "sqlite":
             self.set_sqlite_pragmas()
@@ -84,30 +75,21 @@ class Storage(object):
         except OperationalError:
             pass
 
-    def enqueue_job(self, j):
+    def enqueue_job(self, j, queue):
         """
         Add the job given by j to the job queue.
 
         Note: Does not actually run the job.
         """
-        job_id = uuid.uuid4().hex
-        j.job_id = job_id
-
         with self.session_scope() as session:
-            orm_job = ORMJob(
-                id=job_id,
-                state=j.state,
-                app=self.app,
-                namespace=self.namespace,
-                obj=j)
+            orm_job = ORMJob(id=j.job_id, state=j.state, queue=queue, obj=j)
             session.add(orm_job)
             try:
                 session.commit()
             except Exception as e:
-                logging.error(
-                    "Got an error running session.commit(): {}".format(e))
+                logging.error("Got an error running session.commit(): {}".format(e))
 
-            return job_id
+            return j.job_id
 
     def mark_job_as_canceled(self, job_id):
         """
@@ -126,36 +108,46 @@ class Storage(object):
         """
         self._update_job(job_id, State.CANCELING)
 
-    def get_next_queued_job(self):
+    def get_next_queued_job(self, queues):
         with self.session_scope() as s:
-            orm_job = self._ns_query(s).filter_by(
-                state=State.QUEUED).order_by(ORMJob.queue_order).first()
+            orm_job = (
+                s.query(ORMJob)
+                .filter(ORMJob.queue.in_(queues))
+                .filter_by(state=State.QUEUED)
+                .order_by(ORMJob.queue_order)
+                .first()
+            )
             if orm_job:
                 job = orm_job.obj
             else:
                 job = None
             return job
 
-    def get_canceling_jobs(self):
+    def get_canceling_jobs(self, queues):
         with self.session_scope() as s:
-            jobs = self._ns_query(s).filter_by(state=State.CANCELING).order_by(ORMJob.queue_order)
+            jobs = (
+                s.query(ORMJob)
+                .filter(ORMJob.queue.in_(queues))
+                .filter_by(state=State.CANCELING)
+                .order_by(ORMJob.queue_order)
+            )
             return [job.obj for job in jobs]
 
-    def get_all_jobs(self):
+    def get_all_jobs(self, queue):
         with self.session_scope() as s:
-            orm_jobs = self._ns_query(s).all()
+            orm_jobs = s.query(ORMJob).filter(ORMJob.queue == queue).all()
             return [o.obj for o in orm_jobs]
 
-    def count_all_jobs(self):
+    def count_all_jobs(self, queue):
         with self.session_scope() as s:
-            return self._ns_query(s).count()
+            return s.query(ORMJob).filter(ORMJob.queue == queue).count()
 
     def get_job(self, job_id):
         with self.session_scope() as session:
             job, _ = self._get_job_and_orm_job(job_id, session)
             return job
 
-    def clear(self, job_id=None, force=False):
+    def clear(self, queue=None, job_id=None, force=False):
         """
         Clear the queue and the job data.
         If force is True, clear all jobs, otherwise only delete jobs that are in a finished state,
@@ -166,14 +158,21 @@ class Storage(object):
         :param force: If True, clear the job (or jobs), even if it hasn't completed, failed or been cancelled.
         """
         with self.session_scope() as s:
-            q = self._ns_query(s)
+            q = s.query(ORMJob)
+            if queue:
+                q = q.filter_by(queue=queue)
             if job_id:
                 q = q.filter_by(id=job_id)
 
             # filter only by the finished jobs, if we are not specified to force
             if not force:
                 q = q.filter(
-                    or_(ORMJob.state == State.COMPLETED, ORMJob.state == State.FAILED, ORMJob.state == State.CANCELED))
+                    or_(
+                        ORMJob.state == State.COMPLETED,
+                        ORMJob.state == State.FAILED,
+                        ORMJob.state == State.CANCELED,
+                    )
+                )
 
             q.delete(synchronize_session=False)
 
@@ -233,18 +232,8 @@ class Storage(object):
             return job, orm_job
 
     def _get_job_and_orm_job(self, job_id, session):
-        orm_job = self._ns_query(session).filter_by(id=job_id).one_or_none()
+        orm_job = session.query(ORMJob).filter_by(id=job_id).one_or_none()
         if orm_job is None:
             raise JobNotFound()
         job = orm_job.obj
         return job, orm_job
-
-    def _ns_query(self, session):
-        """
-        Return a SQLAlchemy query that is already namespaced by the app and namespace given to this backend
-        during initialization.
-        Returns: a SQLAlchemy query object
-
-        """
-        return session.query(ORMJob).filter(ORMJob.app == self.app,
-                                            ORMJob.namespace == self.namespace)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -106,12 +106,12 @@ class TestScheduler(object):
         with pytest.raises(ValueError):
             scheduler.schedule(now, id, interval=0, repeat=None)
 
-    def test_scheduled_repeating_function_sets_new_job(self, scheduler):
+    def test_scheduled_repeating_function_updates_old_job(self, scheduler):
         now = datetime.datetime.utcnow()
         old_id = scheduler.schedule(now, id, interval=1000, repeat=None)
         scheduler.check_schedule()
         new_id = scheduler.get_jobs()[0].job_id
-        assert old_id != new_id
+        assert old_id == new_id
 
     def test_scheduled_repeating_function_sets_endless_repeat_new_job(self, scheduler):
         now = datetime.datetime.utcnow()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,130 @@
+import datetime
+import tempfile
+
+import pytest
+from iceqube.exceptions import JobNotFound
+from iceqube.queue import Queue
+from iceqube.scheduler import Scheduler
+
+
+@pytest.fixture
+def queue():
+    with tempfile.NamedTemporaryFile() as f:
+        q = Queue("pytest", storage_path=f.name)
+        yield q
+
+
+@pytest.fixture
+def scheduler(queue):
+    with tempfile.NamedTemporaryFile() as f:
+        s = Scheduler(queue, storage_path=f.name)
+        yield s
+
+
+class TestScheduler(object):
+    def test_enqueue_at_a_function(self, scheduler):
+        job_id = scheduler.enqueue_at(datetime.datetime.utcnow(), id)
+
+        # is the job recorded in the chosen backend?
+        assert scheduler.get_job(job_id).job_id == job_id
+
+    def test_enqueue_at_a_function_sets_time(self, scheduler):
+        now = datetime.datetime.utcnow()
+        job_id = scheduler.enqueue_at(now, id)
+
+        with scheduler.session_scope() as session:
+            scheduled_job = scheduler._ns_query(session).filter_by(id=job_id).one_or_none()
+            scheduled_time = scheduled_job.scheduled_time
+        assert scheduled_time == now
+
+    def test_enqueue_at_preserves_extra_metadata(self, scheduler):
+        metadata = {"saved": True}
+        job_id = scheduler.enqueue_at(datetime.datetime.utcnow(), id, extra_metadata=metadata)
+
+        # Do we get back the metadata we save?
+        assert scheduler.get_job(job_id).extra_metadata == metadata
+
+    def test_enqueue_in_a_function(self, scheduler):
+        job_id = scheduler.enqueue_in(datetime.timedelta(seconds=1000), id)
+
+        # is the job recorded in the chosen backend?
+        assert scheduler.get_job(job_id).job_id == job_id
+
+    def test_enqueue_in_a_function_sets_time(self, scheduler):
+        diff = datetime.timedelta(seconds=1000)
+        now = datetime.datetime.utcnow()
+        scheduler._now = lambda: now
+        job_id = scheduler.enqueue_in(diff, id)
+
+        with scheduler.session_scope() as session:
+            scheduled_job = scheduler._ns_query(session).filter_by(id=job_id).one_or_none()
+            scheduled_time = scheduled_job.scheduled_time
+        assert scheduled_time == now + diff
+
+    def test_cancel_removes_job(self, scheduler):
+        job_id = scheduler.enqueue_at(datetime.datetime.utcnow(), id)
+
+        scheduler.cancel(job_id)
+
+        with pytest.raises(JobNotFound):
+            scheduler.get_job(job_id)
+
+    def test_schedule_a_function_sets_time(self, scheduler):
+        now = datetime.datetime.utcnow()
+        job_id = scheduler.schedule(now, id)
+
+        with scheduler.session_scope() as session:
+            scheduled_job = scheduler._ns_query(session).filter_by(id=job_id).one_or_none()
+            scheduled_time = scheduled_job.scheduled_time
+        assert scheduled_time == now
+
+    def test_schedule_a_function_gives_value_error_without_datetime(self, scheduler):
+        now = 'test'
+        with pytest.raises(ValueError):
+            scheduler.schedule(now, id)
+
+    def test_schedule_a_function_gives_value_error_repeat_zero_interval(self, scheduler):
+        now = datetime.datetime.utcnow()
+        with pytest.raises(ValueError):
+            scheduler.schedule(now, id, interval=0, repeat=None)
+
+    def test_scheduled_repeating_function_sets_new_job(self, scheduler):
+        now = datetime.datetime.utcnow()
+        old_id = scheduler.schedule(now, id, interval=1000, repeat=None)
+        scheduler.check_schedule()
+        new_id = scheduler.get_jobs()[0].job_id
+        assert old_id != new_id
+
+    def test_scheduled_repeating_function_sets_endless_repeat_new_job(self, scheduler):
+        now = datetime.datetime.utcnow()
+        scheduler.schedule(now, id, interval=1000, repeat=None)
+        scheduler.check_schedule()
+        with scheduler.session_scope() as session:
+            scheduled_job = scheduler._ns_query(session).one_or_none()
+            repeat = scheduled_job.repeat
+        assert repeat is None
+
+    def test_scheduled_repeating_function_enqueues_job(self, scheduler):
+        now = datetime.datetime.utcnow()
+        job_id = scheduler.schedule(now, id, interval=1000, repeat=None)
+        scheduler.check_schedule()
+        assert scheduler.queue.fetch_job(job_id).job_id == job_id
+
+    def test_scheduled_repeating_function_sets_new_job_with_one_fewer_repeats(self, scheduler):
+        now = datetime.datetime.utcnow()
+        scheduler.schedule(now, id, interval=1000, repeat=1)
+        scheduler.check_schedule()
+        with scheduler.session_scope() as session:
+            scheduled_job = scheduler._ns_query(session).one_or_none()
+            repeat = scheduled_job.repeat
+        assert repeat == 0
+
+    def test_scheduled_repeating_function_sets_new_job_at_interval(self, scheduler):
+        now = datetime.datetime.utcnow()
+        scheduler.schedule(now, id, interval=1000, repeat=1)
+        scheduler._now = lambda: now
+        scheduler.check_schedule()
+        with scheduler.session_scope() as session:
+            scheduled_job = scheduler._ns_query(session).one_or_none()
+            scheduled_time = scheduled_job.scheduled_time
+        assert scheduled_time == now + datetime.timedelta(seconds=1000)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -73,3 +73,22 @@ class TestBackend:
 
         # is the job marked as completed?
         assert job.state == State.COMPLETED
+
+    def test_can_requeue_complete_job(self, defaultbackend, simplejob):
+        """
+        When we call backend.complete_job, it should mark the job as finished, and
+        remove it from the queue.
+        """
+
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.complete_job(job_id)
+
+        job = defaultbackend.get_job(job_id)
+
+        # is the job marked as completed?
+        assert job.state == State.COMPLETED
+
+        defaultbackend.enqueue_job(simplejob, QUEUE)
+        requeued_job = defaultbackend.get_job(job_id)
+
+        assert requeued_job.state == State.QUEUED


### PR DESCRIPTION
This PR depends on #39 

It does two things:
1) It makes the worker API parallel to the RQ worker API where a single worker can execute jobs from multiple queues.
2) It adds a scheduler, which allows the scheduling of tasks in a similar way to RQ Scheduler's `enqueue_at`, `enqueue_in` and `schedule` methods. For reasons of simplicity, it does not add the cron interface, but that would be a relatively straightforward extension, by adding a cron parsing library.

c.f. https://github.com/rq/rq-scheduler