### PR TITLE
Don't set running state on update progress.

### DIFF
--- a/src/iceqube/storage.py
+++ b/src/iceqube/storage.py
@@ -206,7 +206,7 @@ class Storage(object):
         :param total_progress: The total progress achievable by the job.
         :return: None
         """
-        self._update_job(job_id, State.RUNNING, progress=progress, total_progress=total_progress)
+        self._update_job(job_id, progress=progress, total_progress=total_progress)
 
     def mark_job_as_failed(self, job_id, exception, traceback):
         """
@@ -228,7 +228,7 @@ class Storage(object):
     def complete_job(self, job_id):
         self._update_job(job_id, State.COMPLETED)
 
-    def _update_job(self, job_id, state, **kwargs):
+    def _update_job(self, job_id, state=None, **kwargs):
         with self.session_scope() as session:
 
             job, orm_job = self._get_job_and_orm_job(job_id, session)
@@ -242,8 +242,8 @@ class Storage(object):
             # field we want to edit, in this case the job.state. That forces
             # SQLAlchemy to re-pickle the object, thus setting it to the correct state.
             job = copy(job)
-
-            orm_job.state = job.state = state
+            if state is not None:
+                orm_job.state = job.state = state
             for kwarg in kwargs:
                 setattr(job, kwarg, kwargs[kwarg])
             orm_job.obj = job


### PR DESCRIPTION
As we now use the DB backend as the single source of truth for job state, and `CANCELING` is now a valid job state that indicates that a job should be cancelled by the worker process, setting `RUNNING` every time a job's progress was updated caused tasks that tracked their own progress to prevent any cancellation happening if they updated their progress before the worker could carry out the cancellation.

Fixes behaviour observed in Kolibri: https://github.com/learningequality/kolibri/pull/5542#issuecomment-497435241