### PR TITLE
Allow an arbitrary SQLAlchemy engine to be passed in for storage.

### DIFF
--- a/src/iceqube/queue.py
+++ b/src/iceqube/queue.py
@@ -5,10 +5,10 @@ DEFAULT_QUEUE = "ICEQUBE_DEFAULT_QUEUE"
 
 
 class Queue(object):
-    def __init__(self, app=DEFAULT_QUEUE, storage_path=None):
-        if storage_path is None:
-            raise ValueError('Storage path must be defined')
-        self.storage = Storage(app, app, storage_path)
+    def __init__(self, app=DEFAULT_QUEUE, connection=None):
+        if connection is None:
+            raise ValueError('Connection must be defined')
+        self.storage = Storage(app, app, connection)
 
     def __len__(self):
         return self.storage.count_all_jobs()

--- a/src/iceqube/storage.py
+++ b/src/iceqube/storage.py
@@ -3,11 +3,10 @@ import uuid
 from contextlib import contextmanager
 from copy import copy
 
-from sqlalchemy import Column, DateTime, Index, Integer, PickleType, String, create_engine, event, func, or_
+from sqlalchemy import Column, DateTime, Index, Integer, PickleType, String, event, func, or_
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import NullPool
 
 from iceqube.classes import State
 from iceqube.exceptions import JobNotFound
@@ -49,17 +48,11 @@ class ORMJob(Base):
 
 class Storage(object):
 
-    def __init__(self, app, namespace, storage_path, *args, **kwargs):
+    def __init__(self, app, namespace, connection, *args, **kwargs):
         self.app = app
         self.namespace = namespace
 
-        storage_path = "sqlite:///{path}".format(path=storage_path)
-        connection_class = NullPool
-
-        self.engine = create_engine(
-            storage_path,
-            connect_args={'check_same_thread': False},
-            poolclass=connection_class)
+        self.engine = connection
         self.set_sqlite_pragmas()
         Base.metadata.create_all(self.engine)
         self.sessionmaker = sessionmaker(bind=self.engine)

--- a/src/iceqube/worker.py
+++ b/src/iceqube/worker.py
@@ -19,17 +19,19 @@ class Empty(Exception):
 
 class Worker(object):
 
-    def __init__(self, app, storage_path, num_workers=3):
+    def __init__(self, app, connection=None, num_workers=3):
         # Internally, we use concurrent.future.Future to run and track
         # job executions. We need to keep track of which future maps to which
         # job they were made from, and we use the job_future_mapping dict to do
         # so.
+        if connection is None:
+            raise ValueError('Connection must be defined')
 
         # Key: future object, Value: job object
         self.job_future_mapping = {}
         # Key: job_id, Value: future object
         self.future_job_mapping = {}
-        self.storage_backend = Storage(app, app, storage_path)
+        self.storage_backend = Storage(app, app, connection)
         self.num_workers = num_workers
 
         self.workers = self.start_workers(num_workers=self.num_workers)

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -206,10 +206,15 @@ class TestQueue(object):
     def test_can_get_notified_of_job_failure(self, inmem_queue):
         job_id = inmem_queue.enqueue(failing_func)
 
-        # sleep for half a second to make us switch to another thread
-        time.sleep(0.5)
+        interval = 0.1
+        time_spent = 0
         job = inmem_queue.fetch_job(job_id)
-        assert job.state in [State.QUEUED, State.FAILED]
+        while job.state != State.FAILED:
+            time.sleep(interval)
+            time_spent += interval
+            job = inmem_queue.fetch_job(job_id)
+            assert time_spent < 5
+        assert job.state == State.FAILED
 
     def test_stringify_func_is_importable(self):
         funcstring = stringify_func(set_flag)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,11 +6,19 @@ from iceqube.classes import State
 from iceqube.utils import stringify_func
 from iceqube.storage import Storage
 
+from sqlalchemy import create_engine
+from sqlalchemy.pool import NullPool
+
 
 @pytest.fixture
 def defaultbackend():
     with tempfile.NamedTemporaryFile() as f:
-        b = Storage(app="pytest", namespace="test", storage_path=f.name)
+        connection = create_engine(
+            "sqlite:///{path}".format(path=f.name),
+            connect_args={'check_same_thread': False},
+            poolclass=NullPool,
+        )
+        b = Storage(app="pytest", namespace="test", connection=connection)
         yield b
         b.clear()
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -6,11 +6,19 @@ from iceqube.classes import Job
 from iceqube.classes import State
 from iceqube.worker import Worker
 
+from sqlalchemy import create_engine
+from sqlalchemy.pool import NullPool
+
 
 @pytest.fixture
 def worker():
     with tempfile.NamedTemporaryFile() as f:
-        b = Worker('test', f.name)
+        connection = create_engine(
+            "sqlite:///{path}".format(path=f.name),
+            connect_args={'check_same_thread': False},
+            poolclass=NullPool,
+        )
+        b = Worker('test', connection)
         yield b
         b.shutdown()
 


### PR DESCRIPTION
Allows an arbitrary SQLAlchemy backend to be used for job storage.

Does this by following @bjester's suggestion of following the redis-q API and accepting a connection object.